### PR TITLE
fix: update job title translation to 'Job Role'

### DIFF
--- a/docs/locales/en/translation.json
+++ b/docs/locales/en/translation.json
@@ -422,7 +422,7 @@
     "confirm_password": "Confirm Password",
     "phone": "Phone Number",
     "note": "Note",
-    "job_title": "Job Title",
+    "job_title": "Job Role",
     "location": "Location",
     "dial_code": "Dial Code",
     "group": "Group",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -422,7 +422,7 @@
     "confirm_password": "Confirm Password",
     "phone": "Phone Number",
     "note": "Note",
-    "job_title": "Job Title",
+    "job_title": "Job Role",
     "location": "Location",
     "dial_code": "Dial Code",
     "group": "Group",


### PR DESCRIPTION
https://trello.com/c/Oq9t7EBU/3526-add-extra-fields-into-students-profile

This pull request updates the English translations in both the documentation and public locale files to use "Job Role" instead of "Job Title". This change ensures consistent terminology across the application.

Translation consistency:

* Changed the value for the `job_title` key from "Job Title" to "Job Role" in both `docs/locales/en/translation.json` and `public/locales/en/translation.json` to standardize language.