### PR TITLE
docs: add CLAUDE.md and slash commands

### DIFF
--- a/.claude/commands/change-card.md
+++ b/.claude/commands/change-card.md
@@ -4,20 +4,42 @@ description: Print a Change Card (branch + commit + Trello description) for the 
 
 Look at the current uncommitted diff (`git status` + `git diff` for unstaged, `git diff --cached` for staged). If there are no local changes, look at the commits on the current branch that are ahead of the upstream.
 
-Then print **only** a Change Card in the project's required format:
+Then print **only** a Change Card in the project's required format. Each piece is its own fenced code block at zero indent so the user can copy any one independently, and the Trello description pastes into Trello as proper markdown (not as an indented code block):
+
+**Branch**
 
 ```
-Branch:  <type>/<base>.<short-kebab-summary>
-Commit:  <type>: <imperative subject, ≤50 chars total (incl. prefix)>
-         <body — omit unless WHY is non-obvious; max 1–2 lines>
+<type>/<base>.<short-kebab-summary>
+```
 
-Trello:  Title — <human readable title>
-         Description —
-         **What**: <1-line summary>
-         **Why**: <reason / linked ticket / motivation>
-         **Files touched**: <comma-separated key paths>
-         **How to test**: <2–4 bullet steps>
-         **Risk / regressions**: <breaking-change flag if API surface changes — this is a published library>
+**Commit**
+
+```
+<type>: <imperative subject, ≤50 chars total (incl. prefix)>
+
+<body — omit unless WHY is non-obvious; max 1–2 lines>
+```
+
+**Trello title**
+
+```
+<human readable title>
+```
+
+**Trello description**
+
+```markdown
+**What**: <1-line summary>
+
+**Why**: <reason / linked ticket / motivation>
+
+**Files touched**: <comma-separated key paths>
+
+**How to test**:
+- <step>
+- <step>
+
+**Risk / regressions**: <breaking-change flag if API surface changes — this is a published library>
 ```
 
 Rules:

--- a/.claude/commands/change-card.md
+++ b/.claude/commands/change-card.md
@@ -1,0 +1,32 @@
+---
+description: Print a Change Card (branch + commit + Trello description) for the changes on the current branch or in the current diff.
+---
+
+Look at the current uncommitted diff (`git status` + `git diff` for unstaged, `git diff --cached` for staged). If there are no local changes, look at the commits on the current branch that are ahead of the upstream.
+
+Then print **only** a Change Card in the project's required format:
+
+```
+Branch:  <type>/<base>.<short-kebab-summary>
+Commit:  <type>: <imperative subject, ≤50 chars total (incl. prefix)>
+         <body — omit unless WHY is non-obvious; max 1–2 lines>
+
+Trello:  Title — <human readable title>
+         Description —
+         **What**: <1-line summary>
+         **Why**: <reason / linked ticket / motivation>
+         **Files touched**: <comma-separated key paths>
+         **How to test**: <2–4 bullet steps>
+         **Risk / regressions**: <breaking-change flag if API surface changes — this is a published library>
+```
+
+Rules:
+- `<type>` ∈ `feat | fix | refactor | docs | chore | perf | style | test`
+- `<base>` = single letter for the branch this PR will merge into: `d` = dev, `m` = main/master, `s` = staging. **Default to `d.`** unless `$ARGUMENTS` or `git status` makes another base obvious.
+- Use lowercase, kebab-case for the branch summary; ≤6 words.
+- Commit subject is imperative ("add", "fix", "remove"), lowercase, no trailing period, **≤50 chars total including the `type:` prefix**.
+- Default to subject-only — include a body only if the why isn't obvious; 1–2 lines max.
+- Flag breaking API-surface changes explicitly in the Trello "Risk / regressions" line — this is a published library consumed by other suada apps.
+- Do NOT run `git commit`, `git push`, `git checkout`, `npm publish`, or `yarn version:*`. Just print the card.
+
+If the user passed an argument ($ARGUMENTS), treat it as additional context about WHY the change was made (use it to fill the Trello `**Why**:` line).

--- a/.claude/commands/lint-changed.md
+++ b/.claude/commands/lint-changed.md
@@ -1,0 +1,13 @@
+---
+description: Run ESLint on the files changed in the current diff and report results.
+---
+
+1. Run `git diff --name-only HEAD` and `git diff --name-only --cached` to find changed files.
+2. Filter to `.ts`, `.tsx`, `.js`, `.jsx` files inside `src/`.
+3. Run `npx eslint <file1> <file2> ...` on the filtered list (don't run `yarn lint` on the whole repo unless the diff is empty).
+4. Report:
+   - Each file's pass/fail status
+   - The error count and first 5 errors per failing file
+   - A one-line summary at the end
+
+If lint reports auto-fixable issues, do NOT run `--fix` automatically. Print the fix command for the user to run.

--- a/.claude/commands/typecheck.md
+++ b/.claude/commands/typecheck.md
@@ -1,0 +1,12 @@
+---
+description: Run TypeScript typecheck (no emit) and report errors concisely.
+---
+
+Run `npx tsc --noEmit --skipLibCheck` from the project root and report:
+- Total error count
+- Errors grouped by file (path + error count)
+- First 10 individual error messages, with `file:line` references in markdown link format
+
+If there are no errors, say so in one line and exit.
+
+Do NOT attempt to fix errors automatically — just report.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# Suada Components
+
+## Project Overview
+
+Shared React UI component library consumed by `suada-students`, `suada-admin`, and other Suada front-ends. Built as an npm package with TypeScript, MUI, and styled-components. Bundled with Rollup, dev-previewed with Vite, documented with Storybook.
+
+- **Package name**: `suada-components`
+- **Version**: 1.2.1
+- **Type**: ESM (`"type": "module"`)
+- **License**: MIT
+- **Repository**: github.com/Suada-Learning/suada-components
+
+## Working Style (read first)
+
+When you make any code change in this project, end your response with a **Change Card** block in this exact shape so the user can copy/paste each piece:
+
+```
+Branch:  <type>/<base>.<short-kebab-summary>
+Commit:  <type>: <imperative subject, ≤50 chars total (incl. prefix)>
+         <body — omit unless WHY is non-obvious; max 1–2 lines>
+
+Trello:  Title — <human readable title>
+         Description —
+         **What**: <1-line summary of the change>
+         **Why**: <reason / linked ticket / user-facing motivation>
+         **Files touched**: <comma-separated key paths>
+         **How to test**: <2–4 bullet steps>
+         **Risk / regressions**: <areas to re-check, or "none expected">
+```
+
+Rules:
+- Branch convention: `<type>/<base>.<short-kebab-summary>`. `<type>` matches conventional-commits. `<base>` is a **single letter for the branch this PR will merge into**: `d` = dev, `m` = main/master, `s` = staging. Default to `d.`. Example: `feat/d.video-player-controls`.
+- Commit message follows `@commitlint/config-conventional`.
+- This library is consumed by multiple downstream apps — flag any breaking change in the Trello `**Risk / regressions**` line and bump the major version (`yarn version:major`).
+- **Do not run `git checkout`, `git commit`, `git push`, `npm publish`, `yarn version:*`, or hit any Trello API** unless explicitly asked.
+
+## Comment Style (strict)
+
+- **Keep code comments short.** One line max in the common case. Never multi-paragraph blocks above components, styled-components, or hooks.
+- **Only comment the WHY, not the WHAT.** Skip comments that just restate the code.
+- **Never leave "removed" / "deleted" / "previously had" / "was X, now Y" breadcrumbs.** Delete code cleanly. Git history is the source of truth.
+- **Do not narrate refactors in comments.** No `// moved from`, `// renamed from`, `// refactored to use`.
+
+## Tech Stack
+
+- **Framework**: React 18.2 + TypeScript 5.7
+- **Bundler**: Rollup 4 (publish output) + Vite 6 (dev/preview)
+- **UI**: MUI 5 (`@mui/material`, `@mui/icons-material`, `@mui/x-date-pickers`)
+- **CSS**: Emotion 11, styled-components 6.1, SASS 1.83
+- **Forms**: Formik 2.4
+- **i18n**: i18next 24 + react-i18next 15
+- **Date**: date-fns 2.30, moment 2.30
+- **Media**: react-player 2.16, video-react 0.16, hls.js 1.5
+- **Storybook**: 8.5
+
+## Directory Structure
+
+```
+src/
+├── components/     # Library components (exported)
+├── helperFunctions/
+├── icons/          # SVG icon components
+├── theme/          # Theme tokens
+├── types/          # Shared types
+├── global.styles.tsx
+└── index.ts        # Package entry point
+```
+
+Build output goes to `dist/`. Published files: `dist/**` + `svg/**`.
+
+## Commands
+
+```bash
+yarn dev              # Vite dev server for local preview
+yarn build            # Rollup build + tsc + copy-files (publishable output)
+yarn lint             # ESLint
+yarn preview          # Preview built site
+yarn storybook        # Start Storybook on port 6006
+yarn build-storybook  # Build static Storybook
+yarn version:patch    # Bump patch version (CI uses semantic-release)
+yarn version:minor    # Bump minor version
+yarn version:major    # Bump major version
+```
+
+## Exports
+
+Three entry points (see `package.json` → `exports`):
+
+- `suada-components` → main library
+- `suada-components/components` → components subpath
+- `suada-components/icons` → icons subpath
+
+## Commit Convention
+
+Conventional commits. Release automation via `semantic-release` (`@semantic-release/changelog`, `@semantic-release/git`, `@semantic-release/github`, `@semantic-release/npm`). Bumping the version of a published package will propagate to downstream apps when they `yarn upgrade suada-components`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,20 +12,42 @@ Shared React UI component library consumed by `suada-students`, `suada-admin`, a
 
 ## Working Style (read first)
 
-When you make any code change in this project, end your response with a **Change Card** block in this exact shape so the user can copy/paste each piece:
+When you make any code change in this project, end your response with a **Change Card** so the user can copy/paste each piece. The card has four separate copy blocks — branch, commit, Trello title, Trello description — each in its own fenced block at zero indent (so Trello's markdown parser renders the description correctly instead of treating leading whitespace as a code block):
+
+**Branch**
 
 ```
-Branch:  <type>/<base>.<short-kebab-summary>
-Commit:  <type>: <imperative subject, ≤50 chars total (incl. prefix)>
-         <body — omit unless WHY is non-obvious; max 1–2 lines>
+<type>/<base>.<short-kebab-summary>
+```
 
-Trello:  Title — <human readable title>
-         Description —
-         **What**: <1-line summary of the change>
-         **Why**: <reason / linked ticket / user-facing motivation>
-         **Files touched**: <comma-separated key paths>
-         **How to test**: <2–4 bullet steps>
-         **Risk / regressions**: <areas to re-check, or "none expected">
+**Commit**
+
+```
+<type>: <imperative subject, ≤50 chars total (incl. prefix)>
+
+<body — omit unless WHY is non-obvious; max 1–2 lines>
+```
+
+**Trello title**
+
+```
+<human readable title>
+```
+
+**Trello description**
+
+```markdown
+**What**: <1-line summary of the change>
+
+**Why**: <reason / linked ticket / user-facing motivation>
+
+**Files touched**: <comma-separated key paths>
+
+**How to test**:
+- <step>
+- <step>
+
+**Risk / regressions**: <areas to re-check, or "none expected">
 ```
 
 Rules:


### PR DESCRIPTION
https://trello.com/c/omgn0wbN

This pull request adds comprehensive documentation and utility command definitions to improve the developer experience and maintain consistent workflows in the `suada-components` project. It introduces a detailed project overview, strict working and commenting guidelines, and three new Claude command markdown files for common tasks.

**Documentation and workflow guidelines:**

* Added `CLAUDE.md` with a full project overview, working style, comment style, tech stack, directory structure, commands, exports, and commit conventions. This sets clear standards for all contributors and ensures consistency across the project.

**New developer utility commands:**

* [`.claude/commands/change-card.md`](diffhunk://#diff-6000d28b8e134134cc1e8b5eb23dd3125696bc38a462f34518e9fee4e0b46e90R1-R32): Defines a command to print a standardized Change Card (branch, commit, Trello description) for local changes, enforcing strict formatting and branch/commit conventions.
* [`.claude/commands/lint-changed.md`](diffhunk://#diff-1e8d00056c4bebf628c08c05d1bead73bfdd47d40046933e3749afb370faf989R1-R13): Adds a command to run ESLint only on files changed in the current diff, reporting results and suggesting fixes without applying them.
* [`.claude/commands/typecheck.md`](diffhunk://#diff-13d56dbfcfc79f154270114c759a407473ed1b2238bdddbffd81fd45664c75e3R1-R12): Introduces a command to run TypeScript type checking and report errors concisely, grouped by file, with clear output.