### PR TITLE
chore: opt-in commit-card and rename from change-card

### DIFF
--- a/.claude/commands/commit-card.md
+++ b/.claude/commands/commit-card.md
@@ -1,10 +1,10 @@
 ---
-description: Print a Change Card (branch + commit + Trello description) for the changes on the current branch or in the current diff.
+description: Print a Commit Card (branch + commit + Trello description) for the changes on the current branch or in the current diff.
 ---
 
 Look at the current uncommitted diff (`git status` + `git diff` for unstaged, `git diff --cached` for staged). If there are no local changes, look at the commits on the current branch that are ahead of the upstream.
 
-Then print **only** a Change Card in the project's required format. Each piece is its own fenced code block at zero indent so the user can copy any one independently, and the Trello description pastes into Trello as proper markdown (not as an indented code block):
+Then print **only** a Commit Card in the project's required format. Each piece is its own fenced code block at zero indent so the user can copy any one independently, and the Trello description pastes into Trello as proper markdown (not as an indented code block):
 
 **Branch**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,51 +10,9 @@ Shared React UI component library consumed by `suada-students`, `suada-admin`, a
 - **License**: MIT
 - **Repository**: github.com/Suada-Learning/suada-components
 
-## Working Style (read first)
+## Commit Cards (on request only)
 
-When you make any code change in this project, end your response with a **Change Card** so the user can copy/paste each piece. The card has four separate copy blocks — branch, commit, Trello title, Trello description — each in its own fenced block at zero indent (so Trello's markdown parser renders the description correctly instead of treating leading whitespace as a code block):
-
-**Branch**
-
-```
-<type>/<base>.<short-kebab-summary>
-```
-
-**Commit**
-
-```
-<type>: <imperative subject, ≤50 chars total (incl. prefix)>
-
-<body — omit unless WHY is non-obvious; max 1–2 lines>
-```
-
-**Trello title**
-
-```
-<human readable title>
-```
-
-**Trello description**
-
-```markdown
-**What**: <1-line summary of the change>
-
-**Why**: <reason / linked ticket / user-facing motivation>
-
-**Files touched**: <comma-separated key paths>
-
-**How to test**:
-- <step>
-- <step>
-
-**Risk / regressions**: <areas to re-check, or "none expected">
-```
-
-Rules:
-- Branch convention: `<type>/<base>.<short-kebab-summary>`. `<type>` matches conventional-commits. `<base>` is a **single letter for the branch this PR will merge into**: `d` = dev, `m` = main/master, `s` = staging. Default to `d.`. Example: `feat/d.video-player-controls`.
-- Commit message follows `@commitlint/config-conventional`.
-- This library is consumed by multiple downstream apps — flag any breaking change in the Trello `**Risk / regressions**` line and bump the major version (`yarn version:major`).
-- **Do not run `git checkout`, `git commit`, `git push`, `npm publish`, `yarn version:*`, or hit any Trello API** unless explicitly asked.
+Do **not** auto-emit a Commit Card at the end of every response. Only print one when the user explicitly asks (e.g. "give me a branch name", "what should I commit this as", "draft the Trello card") — at that point run the `/commit-card` slash command or invoke the `commit-card` / `suada-commit-card` skill, which prints the four-block branch / commit / Trello-title / Trello-description format. This library is consumed by multiple downstream apps — when you do print a card, flag any breaking change in the Trello `**Risk / regressions**` line. Print-only: never run `git checkout`, `git commit`, `git push`, `npm publish`, `yarn version:*`, or hit any Trello API unless explicitly asked.
 
 ## Comment Style (strict)
 


### PR DESCRIPTION
https://trello.com/c/omgn0wbN

This pull request updates project documentation to clarify the usage of Commit Cards and renames related files for consistency. The main focus is to ensure Commit Cards are only generated on explicit request and to align terminology across the project.

**Commit Card process and documentation updates:**

* Updated `CLAUDE.md` to specify that Commit Cards should only be generated when explicitly requested, rather than automatically after every change. The instructions for generating and using Commit Cards have been streamlined and moved under a new section, with clear guidance on when and how to use them.

**Terminology and file naming consistency:**

* Renamed `.claude/commands/change-card.md` to `.claude/commands/commit-card.md` and updated its description and instructions to use "Commit Card" instead of "Change Card," ensuring consistent terminology throughout the documentation.